### PR TITLE
fix 二级目录下的机器，无法使用event.ClassHandle

### DIFF
--- a/plugins/lib/event.tin
+++ b/plugins/lib/event.tin
@@ -349,7 +349,7 @@ VAR {当前正在处理的 TinTin++ 事件 %0}   gTTEventArgZero     {};
         #return;
     };
 
-    #if { "$event" != "{[A-Za-z0-9. -]+}" } {
+    #if { "$event" != "{[A-Za-z0-9. -/]+}" } {
         xtt.Usage $method 事件名称不是合法的标识符名称;
         #return;
     };


### PR DESCRIPTION
 ttevent.handle 在判断event的格式的时候，没有兼容 / 这种形式。 
导致的问题： 假如一个脚本使用了event.ClassHandle，并且放在 二级目录下面， 比如 plugins/job/ngwl.tin  这样一个位置，LM job/ngwl的时候会报错。